### PR TITLE
Add command manual and documentations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Go
+name: Build
 on: [push, pull_request]
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Apache SkyWalking CLI
 ===============
 
+![](https://github.com/apache/skywalking-cli/workflows/Build/badge.svg?branch=master)
+![](https://codecov.io/gh/apache/skywalking-cli/branch/master/graph/badge.svg)
+
 <img src="http://skywalking.apache.org/assets/logo.svg" alt="Sky Walking logo" height="90px" align="right" />
 
 The CLI (Command Line Interface) for [Apache SkyWalking](https://github.com/apache/skywalking).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,53 @@ The CLI (Command Line Interface) for [Apache SkyWalking](https://github.com/apac
 SkyWalking CLI is a command interaction tool for the SkyWalking user or OPS team, as an alternative besides using browser GUI.
 It is based on SkyWalking [GraphQL query protocol](https://github.com/apache/skywalking-query-protocol), same as GUI.
 
-# Commands
-TODO
+# Install
+As SkyWalking CLI is using `Makefile`, compiling the project is as easy as executing a command in the root directory of the project.
 
-# Compiling project
-TODO
+```shell
+git clone https://github.com/apache/skywalking-cli
+cd skywalking-cli
+make clean && make
+```
+
+and copy the `./bin/swctl` to your `PATH` directory, usually `/usr/bin/` or `/usr/local/bin`, or you can copy it to any directory you like,
+and add that directory to `PATH`.
+
+# Commands
+Commands in SkyWalking CLI are organized into two levels, in the form of `swctl --option <level1> --option <level2> --option`,
+there're options in each level, which should follow right after the corresponding command, take the following command as example:
+
+```shell
+$ swctl --debug service list --start="2019-11-11" --end="2019-11-12"
+```
+
+where `--debug` is is an option of `swctl`, and since the `swctl` is a top-level command, `--debug` is also called global option,
+and `--start` is an option of the third level command `list`, there is no option for the second level command `service`.
+
+Generally, the second level commands are entity related, there're entities like `service`, `service instance`, `metrics` in SkyWalking,
+and we have corresponding sub-command like `service`; the third level commands are operations on the entities, such as `list` command
+will list all the `service`s, `service instance`s, etc.
+
+## All available commands
+This section covers all the available commands in SkyWalking CLI and their usages
+
+### `service` sub-command
+`service` sub-command (second level command) is an entry for all operations related to services, and it also has some sub-commands.
+
+#### `service list [--start=<start time>] [--end=<end time>]`
+`service list` lists all the services in the time range of \[`start`, `end`\].
+`--start` and `--end` are both optional, and their default values follow the rules below:
+
+- when `start` and `end` are both absent, `start = now - 30 minutes` and `end = now`, namely past 30 minutes;
+- when `start` and `end` are both present, they are aligned to same precision by **truncating the more precise one**,
+e.g. if `start = 2019-01-01 1234, end = 2019-01-01 18`, then `start` is truncated (because it's more precise) to `2019-01-01 12`,
+and `end = 2019-01-01 18`;
+- when `start` is absent and `end` is present, will determine the precision of `end` and then use the precision to calculate `start` (minus 30 units),
+e.g. `end = 2019-11-09 1234`, the precision is `MINUTE`, so `start = end - 30 minutes = 2019-11-09 1204`,
+and if `end = 2019-11-09 12`, the precision is `HOUR`, so `start = end - 30HOUR = 2019-11-08 06`;
+- when `start` is present and `end` is absent, will determine the precision of `start` and then use the precision to calculate `end` (plus 30 units),
+e.g. `start = 2019-11-09 1204`, the precision is `MINUTE`, so `end = start + 30 minutes = 2019-11-09 1234`,
+and if `start = 2019-11-08 06`, the precision is `HOUR`, so `end = start + 30HOUR = 2019-11-09 12`;
 
 # License
 [Apache 2.0 License.](/LICENSE)


### PR DESCRIPTION
The GitHub Action name was `Go`, and the badge is ![](https://github.com/apache/skywalking-cli/workflows/Go/badge.svg?branch=master), which is somewhat odd, so I change it to `Build`, and the code coverage is ![](https://codecov.io/gh/apache/skywalking-cli/branch/master/graph/badge.svg)