### PR TITLE
[Feature] Support multiple display styles, JSON, YAML, ASCII Table

### DIFF
--- a/commands/flags/duration.go
+++ b/commands/flags/duration.go
@@ -16,43 +16,33 @@
  *
  */
 
-package service
+package flags
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/apache/skywalking-cli/commands/flags"
-	"github.com/apache/skywalking-cli/commands/interceptor"
 	"github.com/apache/skywalking-cli/commands/model"
-	"github.com/apache/skywalking-cli/graphql/client"
 	"github.com/apache/skywalking-cli/graphql/schema"
 	"github.com/urfave/cli"
 )
 
-var ListCommand = cli.Command{
-	Name:      "list",
-	ShortName: "ls",
-	Usage:     "List all available services",
-	Flags:     flags.DurationFlags,
-	Before: interceptor.BeforeChain([]cli.BeforeFunc{
-		interceptor.DurationInterceptor,
-	}),
-	Action: func(ctx *cli.Context) error {
-		end := ctx.String("end")
-		start := ctx.String("start")
-		step := ctx.Generic("step")
-		services := client.Services(schema.Duration{
-			Start: start,
-			End:   end,
-			Step:  step.(*model.StepEnumValue).Selected,
-		})
-
-		if bytes, e := json.Marshal(services); e == nil {
-			fmt.Printf("%v\n", string(bytes))
-		} else {
-			return e
-		}
-
-		return nil
+// DurationFlags are common flags that involves a duration, composed
+// by a start time, an end time, and a step, which is commonly used
+// in most of the commands
+var DurationFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "start",
+		Usage: "query start `TIME`",
+	},
+	cli.StringFlag{
+		Name:  "end",
+		Usage: "query end `TIME`",
+	},
+	cli.GenericFlag{
+		Name:   "step",
+		Hidden: true,
+		Value: &model.StepEnumValue{
+			Enum:     schema.AllStep,
+			Default:  schema.StepMinute,
+			Selected: schema.StepMinute,
+		},
 	},
 }

--- a/commands/service/list.go
+++ b/commands/service/list.go
@@ -19,11 +19,10 @@
 package service
 
 import (
-	"encoding/json"
-	"fmt"
 	"github.com/apache/skywalking-cli/commands/flags"
 	"github.com/apache/skywalking-cli/commands/interceptor"
 	"github.com/apache/skywalking-cli/commands/model"
+	"github.com/apache/skywalking-cli/display"
 	"github.com/apache/skywalking-cli/graphql/client"
 	"github.com/apache/skywalking-cli/graphql/schema"
 	"github.com/urfave/cli"
@@ -41,18 +40,12 @@ var ListCommand = cli.Command{
 		end := ctx.String("end")
 		start := ctx.String("start")
 		step := ctx.Generic("step")
-		services := client.Services(schema.Duration{
+		services := client.Services(ctx, schema.Duration{
 			Start: start,
 			End:   end,
 			Step:  step.(*model.StepEnumValue).Selected,
 		})
 
-		if bytes, e := json.Marshal(services); e == nil {
-			fmt.Printf("%v\n", string(bytes))
-		} else {
-			return e
-		}
-
-		return nil
+		return display.Display(ctx, services)
 	},
 }

--- a/display/display.go
+++ b/display/display.go
@@ -16,10 +16,36 @@
  *
  */
 
-package config
+package display
 
-var Config struct {
-	Global struct {
-		BaseURL string `yaml:"base-url"`
+import (
+	"errors"
+	"fmt"
+	"github.com/apache/skywalking-cli/display/json"
+	"github.com/apache/skywalking-cli/display/table"
+	"github.com/apache/skywalking-cli/display/yaml"
+	"github.com/urfave/cli"
+	"strings"
+)
+
+const (
+	Json  string = "json"
+	Yaml  string = "yaml"
+	Table string = "table"
+)
+
+// Display the object in the style specified in flag --display
+func Display(ctx *cli.Context, object interface{}) error {
+	displayStyle := ctx.GlobalString("display")
+
+	switch strings.ToLower(displayStyle) {
+	case Json:
+		return json.Display(object)
+	case Yaml:
+		return yaml.Display(object)
+	case Table:
+		return table.Display(object)
+	default:
+		return errors.New(fmt.Sprintf("unsupported display style: %s", displayStyle))
 	}
 }

--- a/display/display.go
+++ b/display/display.go
@@ -19,7 +19,6 @@
 package display
 
 import (
-	"errors"
 	"fmt"
 	"github.com/apache/skywalking-cli/display/json"
 	"github.com/apache/skywalking-cli/display/table"
@@ -46,6 +45,6 @@ func Display(ctx *cli.Context, object interface{}) error {
 	case Table:
 		return table.Display(object)
 	default:
-		return errors.New(fmt.Sprintf("unsupported display style: %s", displayStyle))
+		return fmt.Errorf("unsupported display style: %s", displayStyle)
 	}
 }

--- a/display/json/json.go
+++ b/display/json/json.go
@@ -16,37 +16,19 @@
  *
  */
 
-package client
+package json
 
 import (
-	"context"
-	"github.com/apache/skywalking-cli/graphql/schema"
-	"github.com/apache/skywalking-cli/logger"
-	"github.com/machinebox/graphql"
-	"github.com/urfave/cli"
+	"encoding/json"
+	"fmt"
 )
 
-func Services(cliCtx *cli.Context, duration schema.Duration) []schema.Service {
-	client := graphql.NewClient(cliCtx.GlobalString("base-url"))
-	client.Log = func(msg string) {
-		logger.Log.Debugln(msg)
+func Display(object interface{}) error {
+	if bytes, e := json.Marshal(object); e == nil {
+		fmt.Printf("%v\n", string(bytes))
+	} else {
+		return e
 	}
 
-	var response map[string][]schema.Service
-	request := graphql.NewRequest(`
-		query ($duration: Duration!) {
-			services: getAllServices(duration: $duration) {
-				id name
-			}
-		}
-	`)
-	request.Var("duration", duration)
-
-	ctx := context.Background()
-	if err := client.Run(ctx, request, &response); err != nil {
-		logger.Log.Fatalln(err)
-		panic(err)
-	}
-
-	return response["services"]
+	return nil
 }

--- a/display/yaml/yaml.go
+++ b/display/yaml/yaml.go
@@ -16,37 +16,19 @@
  *
  */
 
-package client
+package yaml
 
 import (
-	"context"
-	"github.com/apache/skywalking-cli/graphql/schema"
-	"github.com/apache/skywalking-cli/logger"
-	"github.com/machinebox/graphql"
-	"github.com/urfave/cli"
+	"fmt"
+	"gopkg.in/yaml.v2"
 )
 
-func Services(cliCtx *cli.Context, duration schema.Duration) []schema.Service {
-	client := graphql.NewClient(cliCtx.GlobalString("base-url"))
-	client.Log = func(msg string) {
-		logger.Log.Debugln(msg)
+func Display(object interface{}) error {
+	if bytes, e := yaml.Marshal(object); e == nil {
+		fmt.Printf("%v", string(bytes))
+	} else {
+		return e
 	}
 
-	var response map[string][]schema.Service
-	request := graphql.NewRequest(`
-		query ($duration: Duration!) {
-			services: getAllServices(duration: $duration) {
-				id name
-			}
-		}
-	`)
-	request.Var("duration", duration)
-
-	ctx := context.Background()
-	if err := client.Run(ctx, request, &response); err != nil {
-		logger.Log.Fatalln(err)
-		panic(err)
-	}
-
-	return response["services"]
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/machinebox/graphql v0.2.2
+	github.com/olekukonko/tablewriter v0.0.2
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -7,6 +8,11 @@ github.com/lytics/logrus v0.0.0-20170528191427-4389a17ed024 h1:QaKVrqyQRNPbdBNCp
 github.com/lytics/logrus v0.0.0-20170528191427-4389a17ed024/go.mod h1:SkQviJ2s7rFyzyuxdVp6osZceHOabU91ZhKsEXF0RWg=
 github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkBZfo=
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.2 h1:sq53g+DWf0J6/ceFUHpQ0nAEb6WgM++fq16MZ91cS6o=
+github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Seems that people like table style, https://github.com/apache/skywalking-cli/pull/6#discussion_r343972888 , https://github.com/apache/skywalking-cli/pull/6#issuecomment-551076830 , this patch abstract a display layer and provides several display style implementations, JSON, YAML and ASCII table, works like this:

```shell
skywalking-cli (feature/display-styles $) -> ./bin/swctl --display=table --debug=false service ls 
+----+----------+
| ID |   NAME   |
+----+----------+
|  4 | projectA |
|  2 | projectB |
|  5 | projectD |
|  3 | projectC |
+----+----------+

skywalking-cli (feature/display-styles $) -> ./bin/swctl --display=json --debug=false service ls 
[{"id":"4","name":"projectA"},{"id":"2","name":"projectB"},{"id":"5","name":"projectD"},{"id":"3","name":"projectC"}]

skywalking-cli (feature/display-styles $) -> ./bin/swctl --display=yaml --debug=false service ls 
- id: "4"
  name: projectA
- id: "2"
  name: projectB
- id: "5"
  name: projectD
- id: "3"
  name: projectC

skywalking-cli (feature/display-styles $) -> 
```

will supplement the related documentations after #8 is merged