### PR TITLE
[Enhancement] List single service by service name

### DIFF
--- a/graphql/client/client.go
+++ b/graphql/client/client.go
@@ -86,8 +86,8 @@ func SearchService(cliCtx *cli.Context, serviceCode string) (service schema.Serv
 	var response map[string]schema.Service
 	request := graphql.NewRequest(`
 		query searchService($serviceCode: String!) {
-    		service: searchService(serviceCode: $serviceCode) {
-      				id name
+			service: searchService(serviceCode: $serviceCode) {
+				id name
 			}
 		}
 	`)


### PR DESCRIPTION
When there're too many services in production environment and we just want to get only one service id by its service name, this feature will be useful.

```shell
skywalking-cli $ ./bin/swctl service list --help
NAME:
   swctl service list - List services

USAGE:
   swctl service list [command options] <service name>

DESCRIPTION:
   list all services if no <service name> is given, otherwise, only list the given service

OPTIONS:
   --start TIME  query start TIME
   --end TIME    query end TIME

skywalking-cli $ ./bin/swctl service list projectD | jq
[
  {
    "id": "7",
    "name": "projectD"
  }
]

```