### PR TITLE
Add release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ VERSION ?= latest
 OUT_DIR = bin
 BINARY = swctl
 
+RELEASE_BIN = skywalking-cli-$(VERSION)-bin
+RELEASE_SRC = skywalking-cli-$(VERSION)-src
+
 OS = $(shell uname)
 
 GO = go
@@ -79,5 +82,29 @@ coverage: test
 .PHONY: clean
 clean:
 	$(GO_CLEAN) ./...
-	-rm -rf ./bin
+	-rm -rf bin
 	-rm -rf coverage.txt
+	-rm -rf *.tgz
+	-rm -rf *.tgz
+	-rm -rf *.asc
+	-rm -rf *.sha512
+
+release-src: clean
+	-tar -zcvf $(RELEASE_SRC).tgz \
+	--exclude bin \
+	--exclude .git \
+	--exclude .idea \
+	--exclude .DS_Store \
+	--exclude .github \
+	--exclude $(RELEASE_SRC).tgz \
+	.
+
+release-bin: build
+	-mkdir $(RELEASE_BIN)
+	-cp -R bin $(RELEASE_BIN)
+	-tar -zcvf $(RELEASE_BIN).tgz $(RELEASE_BIN)
+	-rm -rf $(RELEASE_BIN)
+
+release: verify license release-src release-bin
+	gpg --batch --yes --armor --detach-sig $(RELEASE_SRC).tgz
+	shasum -a 512 $(RELEASE_SRC).tgz > $(RELEASE_SRC).tgz.sha512


### PR DESCRIPTION
### Create release (including src and bin)

```shell
skywalking-cli $ make VERSION=0.1.0 release
go clean ./...
rm -rf bin
rm -rf coverage.txt
rm -rf *.tgz
rm -rf *.tgz
rm -rf *.asc
rm -rf *.sha512
$(go env GOPATH)/bin/golangci-lint version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
golangci-lint has version master built from ? on 
$(go env GOPATH)/bin/golangci-lint run -v ./...
INFO [config_reader] Config search paths: [./ /Users/kezhenxu/oss/skywalking-cli /Users/kezhenxu/oss /Users/kezhenxu /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 30 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo gofmt goimports golint gosec gosimple govet ineffassign interfacer lll misspell nakedret staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [lintersdb] Active 30 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo gofmt goimports golint gosec gosimple govet ineffassign interfacer lll misspell nakedret staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (exports_file|files|compiled_files|deps|types_sizes|imports|name) took 233.783592ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 1.880652ms 
INFO [runner/unused/goanalysis] analyzers took 0s with no stages 
INFO [runner/goanalysis_metalinter/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 183, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 183/183, exclude: 0/183, cgo: 183/183, skip_dirs: 183/183, autogenerated_exclude: 183/183, filename_unadjuster: 183/183, skip_files: 183/183, identifier_marker: 183/183 
INFO [runner] processing took 9.097796ms with stages: exclude: 3.361903ms, identifier_marker: 2.778092ms, autogenerated_exclude: 1.595272ms, path_prettifier: 1.098771ms, skip_dirs: 219.527µs, cgo: 26.261µs, filename_unadjuster: 7.936µs, nolint: 6.621µs, max_same_issues: 1.081µs, diff: 651ns, max_from_linter: 321ns, exclude-rules: 294ns, skip_files: 264ns, source_code: 237ns, uniq_by_line: 200ns, path_shortener: 183ns, max_per_file_from_linter: 182ns 
INFO [runner] linters took 101.163825ms with stages: unused: 76.597723ms, goanalysis_metalinter: 15.379329ms 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 5 samples, avg is 69.2MB, max is 69.9MB 
INFO Execution took 350.091758ms                  
go test ./... -coverprofile=coverage.txt -covermode=atomic
?   	github.com/apache/skywalking-cli/commands/endpoint	[no test files]
?   	github.com/apache/skywalking-cli/commands/flags	[no test files]
?   	github.com/apache/skywalking-cli/commands/instance	[no test files]
ok  	github.com/apache/skywalking-cli/commands/interceptor	1.354s	coverage: 56.5% of statements
?   	github.com/apache/skywalking-cli/commands/metrics/linear	[no test files]
?   	github.com/apache/skywalking-cli/commands/metrics/single	[no test files]
?   	github.com/apache/skywalking-cli/commands/model	[no test files]
?   	github.com/apache/skywalking-cli/commands/service	[no test files]
?   	github.com/apache/skywalking-cli/display	[no test files]
?   	github.com/apache/skywalking-cli/display/graph	[no test files]
?   	github.com/apache/skywalking-cli/display/graph/linear	[no test files]
ok  	github.com/apache/skywalking-cli/display/json	0.547s	coverage: 75.0% of statements
ok  	github.com/apache/skywalking-cli/display/table	0.951s	coverage: 100.0% of statements
ok  	github.com/apache/skywalking-cli/display/yaml	0.367s	coverage: 75.0% of statements
?   	github.com/apache/skywalking-cli/graphql/client	[no test files]
?   	github.com/apache/skywalking-cli/graphql/schema	[no test files]
?   	github.com/apache/skywalking-cli/logger	[no test files]
?   	github.com/apache/skywalking-cli/swctl	[no test files]
?   	github.com/apache/skywalking-cli/util	[no test files]
$(go env GOPATH)/bin/go-licenser -version || GO111MODULE=off go get -u github.com/elastic/go-licenser
go-licenser  ()
$(go env GOPATH)/bin/go-licenser -d -licensor='Apache Software Foundation (ASF)' .
tar -zcvf skywalking-cli-0.1.0-src.tgz \
	--exclude bin \
	--exclude .git \
	--exclude .idea \
	--exclude .DS_Store \
	--exclude .github \
	--exclude skywalking-cli-0.1.0-src.tgz \
	.
a .
a ./.asf.yaml
a ./go.mod
a ./swctl
a ./logger
a ./LICENSE
a ./util
a ./dist
a ./Makefile
a ./go.sum
a ./.golangci.yml
a ./NOTICE
a ./README.md
a ./coverage.txt
a ./.gitignore
a ./graphql
a ./CONTRIBUTING.md
a ./display
a ./commands
a ./commands/metrics
a ./commands/flags
a ./commands/endpoint
a ./commands/model
a ./commands/instance
a ./commands/service
a ./commands/interceptor
a ./commands/interceptor/duration.go
a ./commands/interceptor/duration_test.go
a ./commands/interceptor/interceptor.go
a ./commands/service/list.go
a ./commands/service/service.go
a ./commands/instance/list.go
a ./commands/instance/instance.go
a ./commands/instance/search.go
a ./commands/model/step.go
a ./commands/endpoint/list.go
a ./commands/endpoint/endpoint.go
a ./commands/flags/instance.go
a ./commands/flags/duration.go
a ./commands/flags/flags.go
a ./commands/flags/search.go
a ./commands/metrics/linear
a ./commands/metrics/single
a ./commands/metrics/single/single-metrics.go
a ./commands/metrics/linear/linear-metrics.go
a ./display/display.go
a ./display/graph
a ./display/json
a ./display/table
a ./display/yaml
a ./display/yaml/yaml_test.go
a ./display/yaml/yaml.go
a ./display/table/table_test.go
a ./display/table/table.go
a ./display/json/json_test.go
a ./display/json/json.go
a ./display/graph/linear
a ./display/graph/graph.go
a ./display/graph/linear/linear.go
a ./graphql/schema
a ./graphql/client
a ./graphql/client/client.go
a ./graphql/schema/constants.go
a ./graphql/schema/schema.go
a ./dist/LICENSE
a ./dist/licenses
a ./dist/NOTICE
a ./dist/licenses/LICENSE-errors
a ./dist/licenses/LICENSE-tablewriter
a ./dist/licenses/LICENSE-logrus
a ./dist/licenses/LICENSE-cli
a ./dist/licenses/LICENSE-termbox-go
a ./util/io.go
a ./logger/log.go
a ./swctl/main.go
go get -v -t -d ./...
mkdir -p bin
GOOS=windows GOARCH=amd64 go build -v -o bin/swctl-0.1.0-windows-amd64 swctl/main.go
mkdir -p bin
GOOS=linux GOARCH=amd64 go build -v -o bin/swctl-0.1.0-linux-amd64 swctl/main.go
mkdir -p bin
GOOS=darwin GOARCH=amd64 go build -v -o bin/swctl-0.1.0-darwin-amd64 swctl/main.go
mkdir skywalking-cli-0.1.0-bin
cp -R bin skywalking-cli-0.1.0-bin
tar -zcvf skywalking-cli-0.1.0-bin.tgz skywalking-cli-0.1.0-bin
a skywalking-cli-0.1.0-bin
a skywalking-cli-0.1.0-bin/bin
a skywalking-cli-0.1.0-bin/bin/swctl-0.1.0-darwin-amd64
a skywalking-cli-0.1.0-bin/bin/swctl-0.1.0-windows-amd64
a skywalking-cli-0.1.0-bin/bin/swctl-0.1.0-linux-amd64
rm -rf skywalking-cli-0.1.0-bin
gpg --batch --yes --armor --detach-sig skywalking-cli-0.1.0-src.tgz
shasum -a 512 skywalking-cli-0.1.0-src.tgz > skywalking-cli-0.1.0-src.tgz.sha512
```

produces:

```text
skywalking-cli $ ls -l skywalking-cli-0.1.0-*
-rw-r--r--  1 kezhenxu  staff  18177619 Dec  3 20:38 skywalking-cli-0.1.0-bin.tgz
-rw-r--r--  1 kezhenxu  staff     33029 Dec  3 20:38 skywalking-cli-0.1.0-src.tgz
-rw-r--r--  1 kezhenxu  staff       833 Dec  3 20:38 skywalking-cli-0.1.0-src.tgz.asc
-rw-r--r--  1 kezhenxu  staff       159 Dec  3 20:38 skywalking-cli-0.1.0-src.tgz.sha512
```

