### PR TITLE
Set version 0.1.0

### DIFF
--- a/swctl/main.go
+++ b/swctl/main.go
@@ -46,6 +46,7 @@ func init() {
 func main() {
 	app := cli.NewApp()
 	app.Usage = "The CLI (Command Line Interface) for Apache SkyWalking."
+	app.Version = "0.1.0"
 
 	flags := []cli.Flag{
 		altsrc.NewStringFlag(cli.StringFlag{


### PR DESCRIPTION
Simply run `swctl`, the version field is `0.0.0`, this patch set it to `0.1.0` and can be iterated, I think this should be included in 0.1.0

```shell
NAME:
   swctl-latest-darwin-amd64 - The CLI (Command Line Interface) for Apache SkyWalking.

USAGE:
   swctl-latest-darwin-amd64 [global options] command [command options] [arguments...]

VERSION:
   0.0.0

COMMANDS:
   service, s      Service related sub-command
   instance, i     Instance related sub-command
   linear-metrics  Query linear metrics defined in backend OAL
   single-metrics  Query single metrics defined in backend OAL
   endpoint, e     Endpoint related sub-command
   help, h         Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config FILE    load configuration FILE (default: "~/.skywalking.yml")
   --base-url url   base url of the OAP backend graphql (default: "http://127.0.0.1:12800/graphql")
   --debug          enable debug mode, will print more detailed logs
   --display style  display style of the result, supported styles are: json, yaml, table (default: "json")
   --help, -h       show help
   --version, -v    print the version
```

