### PR TITLE
Fix `dashboard global` command cannot return json result

### DIFF
--- a/assets/graphqls/dashboard/LabeledMetricsValues.graphql
+++ b/assets/graphqls/dashboard/LabeledMetricsValues.graphql
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-query ($condition: MetricsCondition!, $label: [String!]!, $duration: Duration!) {
-    result: readLabeledMetricsValues(condition: $condition, labels: $label, duration: $duration) {
+query ($condition: MetricsCondition!, $labels: [String!]!, $duration: Duration!) {
+    result: readLabeledMetricsValues(condition: $condition, labels: $labels, duration: $duration) {
         label
         values {
             values {

--- a/commands/dashboard/global/global.go
+++ b/commands/dashboard/global/global.go
@@ -36,7 +36,17 @@ var GlobalCommand = cli.Command{
 	ShortName:   "g",
 	Usage:       "Display global data",
 	Description: "Display global data",
-	Flags:       flags.DurationFlags,
+	Flags: flags.Flags(
+		flags.DurationFlags,
+		[]cli.Flag{
+			cli.StringFlag{
+				Name:     "template",
+				Usage:    "load dashboard UI template",
+				Required: false,
+				Value:    dashboard.DefaultTemplatePath,
+			},
+		},
+	),
 	Before: interceptor.BeforeChain([]cli.BeforeFunc{
 		interceptor.TimezoneInterceptor,
 		interceptor.DurationInterceptor,


### PR DESCRIPTION
Since the last [PR #46](https://github.com/apache/skywalking-cli/pull/46) changed the configuration of graphql query parameters, the command `dashboard global` could not return the query result in `json` format.