### PR TITLE
Integrate global metrics and global response latency into `dashboard global` command

### DIFF
--- a/assets/templates/Dashboard.Global.json
+++ b/assets/templates/Dashboard.Global.json
@@ -1,4 +1,9 @@
 {
+  "buttons": {
+    "texts": "Metrics, Response Latency",
+    "colorNumber": 220,
+    "height": 1
+  },
   "metrics": [
     {
       "condition": {

--- a/display/graph/dashboard/global.go
+++ b/display/graph/dashboard/global.go
@@ -19,6 +19,7 @@ package dashboard
 
 import (
 	"context"
+	"math"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -51,12 +52,6 @@ const (
 	// layoutLineChart focuses onto the line chart.
 	layoutLineChart
 )
-
-// layoutTypeNames maps layoutType values to human readable names.
-// var layoutTypeNames = map[int]layoutType{
-// 	0: layoutAll,
-// 	1: layoutLineChart,
-// }
 
 // widgets holds the widgets used by the dashboard.
 type widgets struct {
@@ -106,6 +101,8 @@ func newLayoutButtons(c *container.Container, w *widgets, template *dashboard.Bu
 
 // gridLayout prepares container options that represent the desired screen layout.
 func gridLayout(w *widgets, lt layoutType) ([]container.Option, error) {
+	const buttonRowHeight = 15
+
 	buttonColWidthPerc := 100 / len(w.buttons)
 	var buttonCols []grid.Element
 
@@ -114,7 +111,7 @@ func gridLayout(w *widgets, lt layoutType) ([]container.Option, error) {
 	}
 
 	rows := []grid.Element{
-		grid.RowHeightPerc(20, buttonCols...),
+		grid.RowHeightPerc(buttonRowHeight, buttonCols...),
 	}
 
 	switch lt {
@@ -124,14 +121,19 @@ func gridLayout(w *widgets, lt layoutType) ([]container.Option, error) {
 		)
 
 	case layoutLineChart:
-		rows = append(rows,
-			grid.RowHeightPerc(70),
-		)
+		lcElements := linear.LineChartElements(w.linears)
+		percentage := int(math.Min(99, float64((100-buttonRowHeight)/len(lcElements))))
+
+		for _, e := range lcElements {
+			rows = append(rows,
+				grid.RowHeightPerc(percentage, e...),
+			)
+		}
 	}
 
 	builder := grid.New()
 	builder.Add(
-		grid.RowHeightPerc(90, rows...),
+		grid.RowHeightPerc(99, rows...),
 	)
 	gridOpts, err := builder.Build()
 	if err != nil {

--- a/display/graph/dashboard/global.go
+++ b/display/graph/dashboard/global.go
@@ -1,0 +1,234 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dashboard
+
+import (
+	"context"
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/mum4k/termdash"
+	"github.com/mum4k/termdash/container/grid"
+	"github.com/mum4k/termdash/linestyle"
+	"github.com/mum4k/termdash/terminal/termbox"
+	"github.com/mum4k/termdash/terminal/terminalapi"
+	"github.com/urfave/cli"
+
+	"github.com/apache/skywalking-cli/display/graph/gauge"
+	"github.com/apache/skywalking-cli/display/graph/linear"
+	"github.com/apache/skywalking-cli/graphql/dashboard"
+
+	"github.com/mum4k/termdash/cell"
+	"github.com/mum4k/termdash/container"
+	"github.com/mum4k/termdash/widgets/button"
+	"github.com/mum4k/termdash/widgets/linechart"
+)
+
+// rootID is the ID assigned to the root container.
+const rootID = "root"
+
+type layoutType int
+
+const (
+	// layoutAll displays all the widgets.
+	layoutAll layoutType = iota
+
+	// layoutLineChart focuses onto the line chart.
+	layoutLineChart
+)
+
+// layoutTypeNames maps layoutType values to human readable names.
+// var layoutTypeNames = map[int]layoutType{
+// 	0: layoutAll,
+// 	1: layoutLineChart,
+// }
+
+// widgets holds the widgets used by the dashboard.
+type widgets struct {
+	gauges  []*gauge.MetricColumn
+	linears []*linechart.LineChart
+
+	// buttons are used to change the layout.
+	buttons []*button.Button
+}
+
+// setLayout sets the specified layout.
+func setLayout(c *container.Container, w *widgets, lt layoutType) error {
+	gridOpts, err := gridLayout(w, lt)
+	if err != nil {
+		return err
+	}
+	return c.Update(rootID, gridOpts...)
+}
+
+// newLayoutButtons returns buttons that dynamically switch the layouts.
+func newLayoutButtons(c *container.Container, w *widgets, template *dashboard.ButtonTemplate) ([]*button.Button, error) {
+	var buttons []*button.Button
+
+	buttonTexts := strings.Split(template.Texts, ",")
+
+	opts := []button.Option{
+		button.WidthFor(longestString(buttonTexts)),
+		button.FillColor(cell.ColorNumber(template.ColorNum)),
+		button.Height(template.Height),
+	}
+
+	for i, text := range buttonTexts {
+		// declare a local variable lt to avoid closure.
+		lt := layoutType(i)
+
+		b, err := button.New(text, func() error {
+			return setLayout(c, w, lt)
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
+		buttons = append(buttons, b)
+	}
+
+	return buttons, nil
+}
+
+// gridLayout prepares container options that represent the desired screen layout.
+func gridLayout(w *widgets, lt layoutType) ([]container.Option, error) {
+	buttonColWidthPerc := 100 / len(w.buttons)
+	var buttonCols []grid.Element
+
+	for _, b := range w.buttons {
+		buttonCols = append(buttonCols, grid.ColWidthPerc(buttonColWidthPerc, grid.Widget(b)))
+	}
+
+	rows := []grid.Element{
+		grid.RowHeightPerc(20, buttonCols...),
+	}
+
+	switch lt {
+	case layoutAll:
+		rows = append(rows,
+			grid.RowHeightPerc(70, gauge.MetricColumnsElement(w.gauges)...),
+		)
+
+	case layoutLineChart:
+		rows = append(rows,
+			grid.RowHeightPerc(70),
+		)
+	}
+
+	builder := grid.New()
+	builder.Add(
+		grid.RowHeightPerc(90, rows...),
+	)
+	gridOpts, err := builder.Build()
+	if err != nil {
+		return nil, err
+	}
+	return gridOpts, nil
+}
+
+// newWidgets creates all widgets used by the dashboard.
+func newWidgets(data *dashboard.GlobalData, template *dashboard.GlobalTemplate) (*widgets, error) {
+	var columns []*gauge.MetricColumn
+	var linears []*linechart.LineChart
+
+	// Create gauges to display global metrics.
+	for i, t := range template.Metrics {
+		col, err := gauge.NewMetricColumn(data.Metrics[i], &t)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, col)
+	}
+
+	// Create line charts to display global response latency.
+	for _, input := range data.ResponseLatency {
+		l, err := linear.NewLineChart(input)
+		if err != nil {
+			return nil, err
+		}
+		linears = append(linears, l)
+	}
+
+	return &widgets{
+		gauges:  columns,
+		linears: linears,
+	}, nil
+}
+
+func Display(ctx *cli.Context, data *dashboard.GlobalData) error {
+	t, err := termbox.New(termbox.ColorMode(terminalapi.ColorMode256))
+	if err != nil {
+		return err
+	}
+	defer t.Close()
+
+	c, err := container.New(
+		t,
+		container.Border(linestyle.Light),
+		container.BorderTitle("[Global Dashboard]-PRESS Q TO QUIT"),
+		container.ID(rootID))
+	if err != nil {
+		return err
+	}
+
+	template, err := dashboard.LoadTemplate(ctx.String("template"))
+	if err != nil {
+		return err
+	}
+
+	w, err := newWidgets(data, template)
+	if err != nil {
+		panic(err)
+	}
+	lb, err := newLayoutButtons(c, w, &template.Buttons)
+	if err != nil {
+		return err
+	}
+	w.buttons = lb
+
+	gridOpts, err := gridLayout(w, layoutAll)
+	if err != nil {
+		return err
+	}
+
+	if e := c.Update(rootID, gridOpts...); e != nil {
+		return e
+	}
+
+	con, cancel := context.WithCancel(context.Background())
+	quitter := func(keyboard *terminalapi.Keyboard) {
+		if strings.EqualFold(keyboard.Key.String(), "q") {
+			cancel()
+		}
+	}
+
+	err = termdash.Run(con, t, c, termdash.KeyboardSubscriber(quitter))
+
+	return err
+}
+
+// longestString returns the longest string in the string array.
+func longestString(strs []string) (ret string) {
+	maxLen := 0
+	for _, s := range strs {
+		if l := runewidth.StringWidth(s); l > maxLen {
+			ret = s
+			maxLen = l
+		}
+	}
+	return
+}

--- a/display/graph/gauge/gauge.go
+++ b/display/graph/gauge/gauge.go
@@ -110,6 +110,8 @@ func NewMetricColumn(column []*schema.SelectedRecord, config *dashboard.MetricTe
 	return &ret, nil
 }
 
+// MetricColumnsElement is the part that separated from layout,
+// which can be reused by global dashboard.
 func MetricColumnsElement(columns []*MetricColumn) []grid.Element {
 	var metricColumns []grid.Element
 	var columnWidthPerc int

--- a/display/graph/graph.go
+++ b/display/graph/graph.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/urfave/cli"
 
+	db "github.com/apache/skywalking-cli/display/graph/dashboard"
 	"github.com/apache/skywalking-cli/display/graph/gauge"
-
 	"github.com/apache/skywalking-cli/display/graph/tree"
+	"github.com/apache/skywalking-cli/graphql/dashboard"
 
 	"github.com/apache/skywalking-cli/display/graph/heatmap"
 	"github.com/apache/skywalking-cli/graphql/schema"
@@ -40,6 +41,7 @@ type (
 	MultiLinearMetrics = []LinearMetrics
 	Trace              = schema.Trace
 	GlobalMetrics      = [][]*schema.SelectedRecord
+	GlobalData         = dashboard.GlobalData
 )
 
 var (
@@ -48,6 +50,7 @@ var (
 	MultiLinearMetricsType = reflect.TypeOf(MultiLinearMetrics{})
 	TraceType              = reflect.TypeOf(Trace{})
 	GlobalMetricsType      = reflect.TypeOf(GlobalMetrics{})
+	GlobalDataType         = reflect.TypeOf(&GlobalData{})
 )
 
 func Display(ctx *cli.Context, displayable *d.Displayable) error {
@@ -68,6 +71,9 @@ func Display(ctx *cli.Context, displayable *d.Displayable) error {
 
 	case GlobalMetricsType:
 		return gauge.Display(ctx, data.(GlobalMetrics))
+
+	case GlobalDataType:
+		return db.Display(ctx, data.(*GlobalData))
 
 	default:
 		return fmt.Errorf("type of %T is not supported to be displayed as ascii graph", reflect.TypeOf(data))

--- a/display/graph/linear/linear.go
+++ b/display/graph/linear/linear.go
@@ -35,7 +35,7 @@ import (
 
 const RootID = "root"
 
-func newLineChart(inputs map[string]float64) (lineChart *linechart.LineChart, err error) {
+func NewLineChart(inputs map[string]float64) (lineChart *linechart.LineChart, err error) {
 	index := 0
 
 	xLabels := map[int]string{}
@@ -109,7 +109,7 @@ func Display(inputs []map[string]float64) error {
 	var elements []*linechart.LineChart
 
 	for _, input := range inputs {
-		w, e := newLineChart(input)
+		w, e := NewLineChart(input)
 		if e != nil {
 			return e
 		}

--- a/example/Dashboard.Global.json
+++ b/example/Dashboard.Global.json
@@ -1,4 +1,9 @@
 {
+  "buttons": {
+    "texts": "Metrics, Response Latency",
+    "colorNumber": 220,
+    "height": 1
+  },
   "metrics": [
     {
       "condition": {

--- a/graphql/dashboard/global.go
+++ b/graphql/dashboard/global.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/skywalking-cli/graphql/client"
 	"github.com/apache/skywalking-cli/graphql/schema"
 	"github.com/apache/skywalking-cli/graphql/utils"
+	"github.com/apache/skywalking-cli/logger"
 )
 
 type ButtonTemplate struct {
@@ -147,8 +148,9 @@ func responseLatency(ctx *cli.Context, duration schema.Duration) []map[string]fl
 	responseLatency := response["result"]
 	reshaped := make([]map[string]float64, len(responseLatency))
 	for _, mvs := range responseLatency {
-		index, err := strconv.Atoi(*mvs.Label)
+		index, err := strconv.Atoi(strings.TrimSpace(*mvs.Label))
 		if err != nil {
+			logger.Log.Fatalln(err)
 			return nil
 		}
 		reshaped[index] = utils.MetricsToMap(duration, *mvs.Values)


### PR DESCRIPTION
The command `swctl --display graph dashboard global` can display global metrics and global response latency in the form of graph  now.

The next step is to integrate the heat map into the global dashboard.

![image](https://user-images.githubusercontent.com/26627380/89114605-ecc6b700-d4b0-11ea-8c84-9041f418000b.png)
![image](https://user-images.githubusercontent.com/26627380/89114609-f3edc500-d4b0-11ea-83b3-520a120a1a2a.png)
