### PR TITLE
Fix a bug and make several improvements

### DIFF
--- a/assets/templates/Dashboard.Global.json
+++ b/assets/templates/Dashboard.Global.json
@@ -1,6 +1,5 @@
 {
   "buttons": {
-    "texts": "Metrics, Response Latency",
     "colorNumber": 220,
     "height": 1
   },
@@ -56,7 +55,8 @@
         "normal": true
       }
     },
-    "labels": "0, 1, 2, 3, 4",
+    "labels": "P50, P75, P90, P95, P99",
+    "labelsIndex": "0, 1, 2, 3, 4",
     "title": "Global Response Latency",
     "unit": "percentile in ms"
   },

--- a/display/graph/dashboard/global.go
+++ b/display/graph/dashboard/global.go
@@ -62,6 +62,9 @@ type widgets struct {
 	buttons []*button.Button
 }
 
+// linearTitles are titles of each line chart, load from the template file.
+var linearTitles []string
+
 // setLayout sets the specified layout.
 func setLayout(c *container.Container, w *widgets, lt layoutType) error {
 	gridOpts, err := gridLayout(w, lt)
@@ -75,15 +78,13 @@ func setLayout(c *container.Container, w *widgets, lt layoutType) error {
 func newLayoutButtons(c *container.Container, w *widgets, template *dashboard.ButtonTemplate) ([]*button.Button, error) {
 	var buttons []*button.Button
 
-	buttonTexts := strings.Split(template.Texts, ",")
-
 	opts := []button.Option{
-		button.WidthFor(longestString(buttonTexts)),
+		button.WidthFor(longestString(template.Texts)),
 		button.FillColor(cell.ColorNumber(template.ColorNum)),
 		button.Height(template.Height),
 	}
 
-	for i, text := range buttonTexts {
+	for i, text := range template.Texts {
 		// declare a local variable lt to avoid closure.
 		lt := layoutType(i)
 
@@ -121,7 +122,7 @@ func gridLayout(w *widgets, lt layoutType) ([]container.Option, error) {
 		)
 
 	case layoutLineChart:
-		lcElements := linear.LineChartElements(w.linears)
+		lcElements := linear.LineChartElements(w.linears, linearTitles)
 		percentage := int(math.Min(99, float64((100-buttonRowHeight)/len(lcElements))))
 
 		for _, e := range lcElements {
@@ -191,6 +192,7 @@ func Display(ctx *cli.Context, data *dashboard.GlobalData) error {
 	if err != nil {
 		return err
 	}
+	linearTitles = strings.Split(template.ResponseLatency.Labels, ", ")
 
 	w, err := newWidgets(data, template)
 	if err != nil {

--- a/display/graph/linear/linear.go
+++ b/display/graph/linear/linear.go
@@ -66,7 +66,7 @@ func NewLineChart(inputs map[string]float64) (lineChart *linechart.LineChart, er
 
 // LineChartElements is the part that separated from layout,
 // which can be reused by global dashboard.
-func LineChartElements(lineCharts []*linechart.LineChart) [][]grid.Element {
+func LineChartElements(lineCharts []*linechart.LineChart, titles []string) [][]grid.Element {
 	cols := maxSqrt(len(lineCharts))
 
 	rows := make([][]grid.Element, int(math.Ceil(float64(len(lineCharts))/float64(cols))))
@@ -78,13 +78,21 @@ func LineChartElements(lineCharts []*linechart.LineChart) [][]grid.Element {
 			if r == len(rows)-1 {
 				percentage = int(math.Floor(float64(100) / float64(len(lineCharts)-r*cols)))
 			}
+
+			var title string
+			if titles == nil {
+				title = fmt.Sprintf("#%v", r*cols+c)
+			} else {
+				title = titles[r*cols+c]
+			}
+
 			row = append(row, grid.ColWidthPerc(
 				int(math.Min(99, float64(percentage))),
 				grid.Widget(
 					lineCharts[r*cols+c],
 					container.Border(linestyle.Light),
 					container.BorderTitleAlignCenter(),
-					container.BorderTitle(fmt.Sprintf("#%v", r*cols+c)),
+					container.BorderTitle(title),
 				),
 			))
 		}
@@ -130,7 +138,7 @@ func Display(inputs []map[string]float64) error {
 		elements = append(elements, w)
 	}
 
-	gridOpts, err := layout(LineChartElements(elements))
+	gridOpts, err := layout(LineChartElements(elements, nil))
 	if err != nil {
 		return err
 	}

--- a/example/Dashboard.Global.json
+++ b/example/Dashboard.Global.json
@@ -1,6 +1,5 @@
 {
   "buttons": {
-    "texts": "Metrics, Response Latency",
     "colorNumber": 220,
     "height": 1
   },
@@ -56,7 +55,8 @@
         "normal": true
       }
     },
-    "labels": "0, 1, 2, 3, 4",
+    "labels": "P50, P75, P90, P95, P99",
+    "labelsIndex": "0, 1, 2, 3, 4",
     "title": "Global Response Latency",
     "unit": "percentile in ms"
   },


### PR DESCRIPTION
## Bug
+ Due to the use of the wrong delimiter `,` (should be `, `) to split the string as parameters, resulting in the empty data of response latency.

## Improvements
+ Set default values for color and height of buttons.
+ Get titles of buttons from json's keys, instead of hard code.
+ Add check for the existence of items (`metrics`, `responseLatency` and `heatMap`) in the template file.
+ Add meaningful labels for global response latency line charts.

![image](https://user-images.githubusercontent.com/26627380/89301174-e8122680-d69b-11ea-8656-0741ae417819.png)

