### PR TITLE
Add scripts for quick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Then copy the `./bin/swctl-latest-(darwin|linux|windows)-amd64` to your `PATH` d
 usually `/usr/bin/` or `/usr/local/bin`, or you can copy it to any directory you like,
 and add that directory to `PATH`, we recommend you to rename the `swctl-latest-(darwin|linux|windows)-amd64` to `swctl`.
 
+In addition, you can also quickly install through the following methods:
+
+**Install swctl on Linux**
+
+```shell
+sudo ./scripts/install.sh
+```
+
+**Install swctl on Windows**
+
+First you need to start cmd in administrator mode.
+
+```shell
+./scripts/install.bat
+```
+
+
 # Commands
 Commands in SkyWalking CLI are organized into two levels, in the form of `swctl --option <level1> --option <level2> --option`,
 there're options in each level, which should follow right after the corresponding command, take the following command as example:

--- a/README.md
+++ b/README.md
@@ -11,12 +11,33 @@ The CLI (Command Line Interface) for [Apache SkyWalking](https://github.com/apac
 SkyWalking CLI is a command interaction tool for the SkyWalking user or OPS team, as an alternative besides using browser GUI.
 It is based on SkyWalking [GraphQL query protocol](https://github.com/apache/skywalking-query-protocol), same as GUI.
 
-# Download
-Go to the [download page](https://skywalking.apache.org/downloads/) to download all available binaries, including MacOS, Linux, Windows.
-If you want to try the latest features, however, you can compile the latest codes yourself, as the guide below. 
+## Install
 
-# Install
-As SkyWalking CLI is using `Makefile`, compiling the project is as easy as executing a command in the root directory of the project.
+### Quick install
+
+#### Linux or macOS
+
+Install the latest version with the following command:
+
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/apache/skywalking-cli/tree/master/scripts/install.sh)"
+```
+
+#### Windows
+
+Note: you need to start cmd or powershell in administrator mode.
+
+```shell
+curl -LO "https://raw.githubusercontent.com/apache/skywalking-cli/tree/master/scripts/install.bat" && .\install.bat
+```
+
+### Install by available binaries
+
+Go to the [download page](https://skywalking.apache.org/downloads/) to download all available binaries, including macOS, Linux, Windows.
+
+### Build from source
+
+If you want to try the latest features, you can compile the latest source code and build `swctl` by yourself. Since SkyWalking CLI is using `Makefile`, compiling the project is as easy as executing a command in the root directory of the project.
 
 ```shell
 git clone https://github.com/apache/skywalking-cli
@@ -24,26 +45,9 @@ cd skywalking-cli
 make
 ```
 
-Then copy the `./bin/swctl-latest-(darwin|linux|windows)-amd64` to your `PATH` directory according to your OS,
-usually `/usr/bin/` or `/usr/local/bin`, or you can copy it to any directory you like,
-and add that directory to `PATH`, we recommend you to rename the `swctl-latest-(darwin|linux|windows)-amd64` to `swctl`.
+Then copy the `./bin/swctl-latest-(darwin|linux|windows)-amd64` to your `PATH` directory according to your OS, usually `/usr/bin/` or `/usr/local/bin`. 
 
-In addition, you can also quickly install through the following methods:
-
-**Install swctl on Linux or macOS**
-
-```shell
-/bin/bash -c "$(curl -fsSL https://github.com/apache/skywalking-cli/tree/master/scripts/install.sh)"
-```
-
-**Install swctl on Windows**
-
-First you need to start cmd in administrator mode.
-
-```shell
-curl -LO "https://github.com/apache/skywalking-cli/tree/master/scripts/install.bat"
-./install.bat
-```
+You can also copy it to any directory you like, then add that directory to `PATH`. **We recommend you to rename the `swctl-latest-(darwin|linux|windows)-amd64` to `swctl`.**
 
 
 # Commands

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ and add that directory to `PATH`, we recommend you to rename the `swctl-latest-(
 
 In addition, you can also quickly install through the following methods:
 
-**Install swctl on Linux**
+**Install swctl on Linux or macOS**
 
 ```shell
-sudo ./scripts/install.sh
+/bin/bash -c "$(curl -fsSL https://github.com/apache/skywalking-cli/tree/master/scripts/install.sh)"
 ```
 
 **Install swctl on Windows**
@@ -41,7 +41,8 @@ sudo ./scripts/install.sh
 First you need to start cmd in administrator mode.
 
 ```shell
-./scripts/install.bat
+curl -LO "https://github.com/apache/skywalking-cli/tree/master/scripts/install.bat"
+./install.bat
 ```
 
 

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -13,10 +13,11 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-@REM Installation (this requires you to be in privileged mode !)
+@REM Installation (Note: you need to start cmd or powershell in administrator mode.)
 @echo off
 setlocal ENABLEDELAYEDEXPANSION
-@REM  Get the latest version number.
+
+@REM  Get the latest version of swctl.
 set FLAG="FALSE"
 set VERSION= UNKNOW
 curl -LO "https://raw.githubusercontent.com/apache/skywalking-website/master/data/releases.yml"
@@ -30,13 +31,16 @@ if EXIST "releases.yml" (
     )
 )
 set VERSION=%VERSION:~1%
-@echo Latest version: %VERSION%
+@echo The latest version of swctl is %VERSION%
+
 if "%VERSION%" NEQ "UNKNOW" (
-    @REM Download the package.
+
+    @REM Download the binary package.
     curl -LO "https://apache.website-solution.net/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
     if EXIST "skywalking-cli-%VERSION%-bin.tgz" (
         tar -zxvf ".\skywalking-cli-%VERSION%-bin.tgz"
-        @REM Verify the integrity.
+
+        @REM Verify the integrity of the downloaded file.
         curl -LO "https://downloads.apache.org/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz.sha512"
         CertUtil -hashfile skywalking-cli-%VERSION%-bin.tgz sha512 | findstr /X "[0-9a-zA-Z]*" > verify.txt
         for /F "tokens=*" %%i in ( 'type ".\verify.txt"' ) do ( set VERIFY1="%%i  skywalking-cli-%VERSION%-bin.tgz" )
@@ -44,22 +48,23 @@ if "%VERSION%" NEQ "UNKNOW" (
         if "!VERIFY1!" EQU "!VERIFY2!" (
             @echo Through verification, the file is complete.
             mkdir "C:\Program Files\swctl-cli"
+
             @REM Add swctl to the environment variable PATH.
             copy ".\skywalking-cli-%VERSION%-bin\bin\swctl-%VERSION%-windows-amd64" "C:\Program Files\swctl-cli\swctl.exe"
             setx "Path" "C:\Program Files\swctl-cli\;%path%" /m
+
             @REM Delete unnecessary files.
-            del ".\skywalking-cli-%VERSION%-bin.tgz"
-            del ".\verify.txt"
-            del ".\skywalking-cli-%VERSION%-bin.tgz.sha512"
-            del ".\releases.yml"
+            del ".\skywalking-cli-%VERSION%-bin.tgz" ".\verify.txt" 
+            del ".\skywalking-cli-%VERSION%-bin.tgz.sha512" ".\releases.yml"
             rd /S /Q ".\skywalking-cli-%VERSION%-bin"
+            
             @echo Reopen the terminal and type 'swctl --help' to get more information.
         ) else (
             @echo The file is incomplete.
         )
     ) else (
-        @echo Could not found skywalking-cli-%VERSION%-bin.tgz
+        @echo Failed to download skywalking-cli-%VERSION%-bin.tgz
     )
 ) else (
-    @echo Can't get the latest version.
+    @echo Can't get the latest version. The install script may be invalid, try other install methods please.
 )

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,0 +1,55 @@
+@REM Licensed to the Apache Software Foundation (ASF) under one or more
+@REM contributor license agreements.  See the NOTICE file distributed with
+@REM this work for additional information regarding copyright ownership.
+@REM The ASF licenses this file to You under the Apache License, Version 2.0
+@REM (the "License"); you may not use this file except in compliance with
+@REM the License.  You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+@REM Prerequisites
+@REM 1. update change log
+@REM 2. clear milestone issues, and create a new one if needed
+@REM 3. export VERSION=<the version to release>
+
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+set FLAG="FALSE"
+set VERSION="UNKNOW"
+curl -LO "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml"
+@REM Get the latest version number
+for /F "tokens=1,2,*" %%i in ('FINDSTR "name version" "./releases.yml"') do (
+    if !FLAG! EQU "TRUE" (
+        set FLAG="FALSE"
+        set VERSION=%%k
+    )
+    if "%%k" == "SkyWalking CLI" (set FLAG="TRUE")
+)
+del "./releases.yml"
+set VERSION=%VERSION:~1%
+if VERSION NEQ "UNKNOW" (
+    @echo Latest version:%VERSION%
+    @REM Download the package
+    curl -LO "https://apache.osuosl.org/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
+    if EXIST "skywalking-cli-%VERSION%-bin.tgz" (
+        @REM Installation (this requires you to be in privileged mode)
+        tar -zxvf ".\skywalking-cli-%VERSION%-bin.tgz"
+        mkdir "C:\Program Files\swctl-cli"
+        @REM Add swctl to the environment variable PATH
+        copy ".\skywalking-cli-%VERSION%-bin\bin\swctl-%VERSION%-windows-amd64" "C:\Program Files\swctl-cli\swctl.exe"
+        setx "Path" "C:\Program Files\swctl-cli\;%path%" /m
+		del ".\skywalking-cli-%VERSION%-bin.tgz"
+        rd /S /Q ".\skywalking-cli-%VERSION%-bin"
+        @echo Reopen the terminal and type "swctl --help" to get more information.
+    ) else (
+        @echo Could not found "skywalking-cli-%VERSION%-bin.tgz"
+    )
+) else (
+    @echo Can't get the latest version.
+)

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -19,7 +19,7 @@ setlocal ENABLEDELAYEDEXPANSION
 @REM  Get the latest version number.
 set FLAG="FALSE"
 set VERSION= UNKNOW
-curl -LO "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml"
+curl -LO "https://raw.githubusercontent.com/apache/skywalking-website/master/data/releases.yml"
 if EXIST "releases.yml" (
     for /F "tokens=1,2,*" %%i in ('FINDSTR "name version" "./releases.yml"') do (
         if !FLAG! EQU "TRUE" (

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -23,7 +23,7 @@ setlocal ENABLEDELAYEDEXPANSION
 set FLAG="FALSE"
 set VERSION="UNKNOW"
 curl -LO "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml"
-@REM Get the latest version number
+@REM Get the latest version number.
 for /F "tokens=1,2,*" %%i in ('FINDSTR "name version" "./releases.yml"') do (
     if !FLAG! EQU "TRUE" (
         set FLAG="FALSE"
@@ -35,18 +35,18 @@ del "./releases.yml"
 set VERSION=%VERSION:~1%
 if VERSION NEQ "UNKNOW" (
     @echo Latest version:%VERSION%
-    @REM Download the package
+    @REM Download the package.
     curl -LO "https://apache.osuosl.org/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
     if EXIST "skywalking-cli-%VERSION%-bin.tgz" (
-        @REM Installation (this requires you to be in privileged mode)
+        @REM Installation (this requires you to be in privileged mode).
         tar -zxvf ".\skywalking-cli-%VERSION%-bin.tgz"
         mkdir "C:\Program Files\swctl-cli"
-        @REM Add swctl to the environment variable PATH
+        @REM Add swctl to the environment variable PATH.
         copy ".\skywalking-cli-%VERSION%-bin\bin\swctl-%VERSION%-windows-amd64" "C:\Program Files\swctl-cli\swctl.exe"
         setx "Path" "C:\Program Files\swctl-cli\;%path%" /m
 		del ".\skywalking-cli-%VERSION%-bin.tgz"
         rd /S /Q ".\skywalking-cli-%VERSION%-bin"
-        @echo Reopen the terminal and type "swctl --help" to get more information.
+        @echo Type "swctl --help" to get more information.
     ) else (
         @echo Could not found "skywalking-cli-%VERSION%-bin.tgz"
     )

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -30,10 +30,10 @@ if EXIST "releases.yml" (
     )
 )
 set VERSION=%VERSION:~1%
-@echo "Latest version: %VERSION%"
+@echo Latest version: %VERSION%
 if "%VERSION%" NEQ "UNKNOW" (
     @REM Download the package.
-    curl -LO "https://apache.claz.org/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
+    curl -LO "https://www.apache.org/dyn/closer.cgi/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
     if EXIST "skywalking-cli-%VERSION%-bin.tgz" (
         tar -zxvf ".\skywalking-cli-%VERSION%-bin.tgz"
         @REM Verify the integrity.
@@ -42,28 +42,24 @@ if "%VERSION%" NEQ "UNKNOW" (
         for /F "tokens=*" %%i in ( 'type ".\verify.txt"' ) do ( set VERIFY1="%%i  skywalking-cli-%VERSION%-bin.tgz" )
         for /F "tokens=*" %%i in ( 'type ".\skywalking-cli-%VERSION%-bin.tgz.sha512"' ) do ( set VERIFY2="%%i" )
         if "!VERIFY1!" EQU "!VERIFY2!" (
-            if "!VERIFY1!" NEQ "" (
-                @echo "Through verification, the file is complete."
-                mkdir "C:\Program Files\swctl-cli"
-                @REM Add swctl to the environment variable PATH.
-                copy ".\skywalking-cli-%VERSION%-bin\bin\swctl-%VERSION%-windows-amd64" "C:\Program Files\swctl-cli\swctl.exe"
-                setx "Path" "C:\Program Files\swctl-cli\;%path%" /m
-                @REM Delete unnecessary files.
-                del ".\skywalking-cli-%VERSION%-bin.tgz"
-                del ".\verify.txt"
-                del ".\skywalking-cli-%VERSION%-bin.tgz.sha512"
-                del ".\releases.yml"
-                rd /S /Q ".\skywalking-cli-%VERSION%-bin"
-                @echo "Reopen the terminal and type 'swctl --help' to get more information."
-            ) else (
-                @echo "The file is incomplete."
-            )
+            @echo Through verification, the file is complete.
+            mkdir "C:\Program Files\swctl-cli"
+            @REM Add swctl to the environment variable PATH.
+            copy ".\skywalking-cli-%VERSION%-bin\bin\swctl-%VERSION%-windows-amd64" "C:\Program Files\swctl-cli\swctl.exe"
+            setx "Path" "C:\Program Files\swctl-cli\;%path%" /m
+            @REM Delete unnecessary files.
+            del ".\skywalking-cli-%VERSION%-bin.tgz"
+            del ".\verify.txt"
+            del ".\skywalking-cli-%VERSION%-bin.tgz.sha512"
+            del ".\releases.yml"
+            rd /S /Q ".\skywalking-cli-%VERSION%-bin"
+            @echo Reopen the terminal and type 'swctl --help' to get more information.
         ) else (
-            @echo "The file is incomplete."
+            @echo The file is incomplete.
         )
     ) else (
-        @echo "Could not found skywalking-cli-%VERSION%-bin.tgz"
+        @echo Could not found skywalking-cli-%VERSION%-bin.tgz
     )
 ) else (
-    @echo "Can't get the latest version."
+    @echo Can't get the latest version.
 )

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -33,7 +33,7 @@ set VERSION=%VERSION:~1%
 @echo Latest version: %VERSION%
 if "%VERSION%" NEQ "UNKNOW" (
     @REM Download the package.
-    curl -LO "https://www.apache.org/dyn/closer.cgi/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
+    curl -LO "https://apache.website-solution.net/skywalking/cli/%VERSION%/skywalking-cli-%VERSION%-bin.tgz"
     if EXIST "skywalking-cli-%VERSION%-bin.tgz" (
         tar -zxvf ".\skywalking-cli-%VERSION%-bin.tgz"
         @REM Verify the integrity.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@ VERSION=$(curl "https://raw.githubusercontent.com/apache/skywalking-website/mast
 if [ "$VERSION" != "" ]; then
     echo "Latest version: $VERSION"
     # Download the package.
-    curl -LO "https://www.apache.org/dyn/closer.cgi/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
+    curl -LO "https://apache.website-solution.net/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
     if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then
         # Verify the integrity.
         curl -LO "https://downloads.apache.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz.sha512"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prerequisites
+# 1. update change log
+# 2. clear milestone issues, and create a new one if needed
+# 3. export VERSION=<the version to release>
+
+# Get the latest version number
+VERSION=$(curl "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
+if [ $VERSION != "" ]; then
+    echo Latest version:$VERSION
+    # Download the package
+    curl -LO "https://mirrors.advancedhosters.com/apache/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
+    if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then        
+        # Installation
+        tar -zxvf skywalking-cli-$VERSION-bin.tgz 
+        sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
+        sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"
+        sudo rm -rf "./skywalking-cli-0.7.0-bin"
+        echo "Type swctl --help to get more information."
+    else
+        echo Could not found skywalking-cli-$VERSION-bin.tgz
+    fi
+else
+    echo "Can't get the latest version."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Get the latest version number.
-VERSION=$(curl "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
+VERSION=$(curl "https://raw.githubusercontent.com/apache/skywalking-website/master/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
 if [ "$VERSION" != "" ]; then
     echo "Latest version: $VERSION"
     # Download the package.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@ VERSION=$(curl "https://raw.githubusercontent.com/apache/skywalking-website/mast
 if [ "$VERSION" != "" ]; then
     echo "Latest version: $VERSION"
     # Download the package.
-    curl -LO "https://apache.claz.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
+    curl -LO "https://www.apache.org/dyn/closer.cgi/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
     if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then
         # Verify the integrity.
         curl -LO "https://downloads.apache.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz.sha512"
@@ -30,7 +30,11 @@ if [ "$VERSION" != "" ]; then
             echo "Through verification, the file is complete."
             tar -zxvf skywalking-cli-$VERSION-bin.tgz
             # Add swctl to the environment variable PATH.
-            sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
+            if [ "$(uname -s)" = "Darwin" ]; then
+                sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-darwin-amd64 /usr/local/bin/swctl
+            else 
+                sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
+            fi
             # Delete unnecessary files.
             sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz.sha512"
             sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,19 +20,19 @@
 # 2. clear milestone issues, and create a new one if needed
 # 3. export VERSION=<the version to release>
 
-# Get the latest version number
+# Get the latest version number.
 VERSION=$(curl "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
 if [ $VERSION != "" ]; then
     echo Latest version:$VERSION
-    # Download the package
+    # Download the package.
     curl -LO "https://mirrors.advancedhosters.com/apache/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
     if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then        
         # Installation
         tar -zxvf skywalking-cli-$VERSION-bin.tgz 
         sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
         sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"
-        sudo rm -rf "./skywalking-cli-0.7.0-bin"
-        echo "Type swctl --help to get more information."
+        sudo rm -rf "./skywalking-cli-$VERSION-bin"
+        echo "Type 'swctl --help' to get more information."
     else
         echo Could not found skywalking-cli-$VERSION-bin.tgz
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,26 +15,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Prerequisites
-# 1. update change log
-# 2. clear milestone issues, and create a new one if needed
-# 3. export VERSION=<the version to release>
-
 # Get the latest version number.
 VERSION=$(curl "https://endpoint.fastgit.org/https://github.com/apache/skywalking-website/blob/5da4b1082da44c0548b968417005b8f4821c1712/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
-if [ $VERSION != "" ]; then
-    echo Latest version:$VERSION
+if [ "$VERSION" != "" ]; then
+    echo "Latest version: $VERSION"
     # Download the package.
-    curl -LO "https://mirrors.advancedhosters.com/apache/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
-    if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then        
-        # Installation
-        tar -zxvf skywalking-cli-$VERSION-bin.tgz 
-        sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
-        sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"
-        sudo rm -rf "./skywalking-cli-$VERSION-bin"
-        echo "Type 'swctl --help' to get more information."
+    curl -LO "https://apache.claz.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
+    if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then
+        # Verify the integrity.
+        curl -LO "https://downloads.apache.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz.sha512"
+        VERIFY=$(sha512sum --check "skywalking-cli-$VERSION-bin.tgz.sha512")
+        VERIFY="${VERIFY#* }"
+        if [ "$VERIFY" = "OK" ]; then
+            echo "Through verification, the file is complete."
+            tar -zxvf skywalking-cli-$VERSION-bin.tgz
+            # Add swctl to the environment variable PATH.
+            sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
+            # Delete unnecessary files.
+            sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz.sha512"
+            sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"
+            sudo rm -rf "./skywalking-cli-$VERSION-bin"
+            echo "Type 'swctl --help' to get more information."
+        else
+            echo "The file is incomplete."
+        fi
     else
-        echo Could not found skywalking-cli-$VERSION-bin.tgz
+        echo "Could not found skywalking-cli-$VERSION-bin.tgz"
     fi
 else
     echo "Can't get the latest version."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,37 +15,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Get the latest version number.
+# Treat unset variables and parameters other than the special parameters ‘@’ or ‘*’ as an error.
+set -u
+
+# Exit the script with a message.
+abort() {
+  printf "%s\n" "$@"
+  exit 1
+}
+
+# Check if there is a bash.
+if [ -z "${BASH_VERSION:-}" ]; then
+  abort "Bash is required to interpret this install script."
+fi
+
+# Check OS.
+OS="$(uname)"
+if [[ "$OS" != "Darwin" && "$OS" != "Linux" ]]; then
+  abort "The install script is only supported on macOS and Linux."
+fi
+
+check_cmd() {
+    if ! command -v "$@" &> /dev/null 
+    then
+        abort "You must install "$@" before running the install script."
+    fi
+}
+
+# Check if the commands to be used exist.
+for cmd in shasum curl tar awk; do
+  check_cmd $cmd
+done
+
+# Convert the string to lower case.
+OS=$(echo $OS | awk '{print tolower($0)}')
+
+# Get the latest version of swctl.
 VERSION=$(curl "https://raw.githubusercontent.com/apache/skywalking-website/master/data/releases.yml" | grep --after-context=7 "name: SkyWalking CLI" | grep "version" | grep -o "[0-9].[0-9].[0-9]")
 if [ "$VERSION" != "" ]; then
-    echo "Latest version: $VERSION"
-    # Download the package.
-    curl -LO "https://apache.website-solution.net/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz"
+    echo "The latest version of swctl is $VERSION"
+    
+    # Download the binary package.
+    curl -sSLO "https://apache.website-solution.net/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz" > /dev/null
     if [ -f "skywalking-cli-$VERSION-bin.tgz" ]; then
-        # Verify the integrity.
-        curl -LO "https://downloads.apache.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz.sha512"
-        VERIFY=$(sha512sum --check "skywalking-cli-$VERSION-bin.tgz.sha512")
-        VERIFY="${VERIFY#* }"
-        if [ "$VERIFY" = "OK" ]; then
-            echo "Through verification, the file is complete."
+        # Verify the integrity of the downloaded file.
+        curl -sSLO "https://downloads.apache.org/skywalking/cli/$VERSION/skywalking-cli-$VERSION-bin.tgz.sha512" > /dev/null
+        VERIFY=$(shasum -a512 -c "skywalking-cli-$VERSION-bin.tgz.sha512")
+        if [ "${VERIFY#* }" = "OK" ]; then
+            echo "The downloaded file is complete."
             tar -zxvf skywalking-cli-$VERSION-bin.tgz
+            
             # Add swctl to the environment variable PATH.
-            if [ "$(uname -s)" = "Darwin" ]; then
-                sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-darwin-amd64 /usr/local/bin/swctl
-            else 
-                sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-linux-amd64 /usr/local/bin/swctl
-            fi
+            sudo cp skywalking-cli-$VERSION-bin/bin/swctl-$VERSION-$OS-amd64 /usr/local/bin/swctl
+            
             # Delete unnecessary files.
-            sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz.sha512"
-            sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz"
-            sudo rm -rf "./skywalking-cli-$VERSION-bin"
+            sudo rm -rf "./skywalking-cli-$VERSION-bin.tgz.sha512" "./skywalking-cli-$VERSION-bin.tgz" "./skywalking-cli-$VERSION-bin"
+ 
             echo "Type 'swctl --help' to get more information."
         else
-            echo "The file is incomplete."
+            abort "The downloaded file is incomplete."
         fi
     else
-        echo "Could not found skywalking-cli-$VERSION-bin.tgz"
+        abort "Failed to download skywalking-cli-$VERSION-bin.tgz"
     fi
 else
-    echo "Can't get the latest version."
+    echo $VERSION
+    abort "Can't get the latest version. The install script may be invalid, try other install methods please."
 fi


### PR DESCRIPTION
Through the two scripts provided here, users can quickly install swctl.