### PR TITLE
split into multiple workflows to speed up CI

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+code-changes:
+  - '**/*.go'
+  - 'go.mod'
+  - '.golangci.yml'
+  - '.github/*.yml'
+  - '.github/*.yaml'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.14
-        
+
+      - name: Check code generation
+        run: make check-codegen
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Build
+
+name: golangci-lint
 
 on:
   pull_request:
@@ -25,8 +26,8 @@ on:
       - master
 
 jobs:
-  build:
-    name: Build
+  golangci:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,23 +35,12 @@ jobs:
         uses: getsentry/paths-filter@v2
         id: changes
         with:
-            token: ${{ github.token }}
-            filters: .github/file-filters.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: .github/file-filters.yml
 
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14
-        
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: check-diff
-          path: /tmp/swctl/check.diff
-
-      - name: Build
-        run: make build -j3
-
-      - name: Test commands
+      - name: golangci-lint
         if: steps.changes.outputs.code-changes == 'true'
-        run: make test-commands
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.40.1
+          args: --timeout 5m

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+name: license-checker
+
 on:
   pull_request:
   push:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Build
 
 on:
   pull_request:
@@ -25,32 +24,13 @@ on:
       - master
 
 jobs:
-  build:
-    name: Build
+  check-license:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check for go file changes
-        uses: getsentry/paths-filter@v2
-        id: changes
+      - name: Check License Header
+        uses: apache/skywalking-eyes@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            token: ${{ github.token }}
-            filters: .github/file-filters.yml
-
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14
-        
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: check-diff
-          path: /tmp/swctl/check.diff
-
-      - name: Build
-        run: make build -j3
-
-      - name: Test commands
-        if: steps.changes.outputs.code-changes == 'true'
-        run: make test-commands
+          log: info

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+name: unit-test
+
 on:
   pull_request:
   push:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Build
 
 on:
   pull_request:
@@ -25,8 +24,7 @@ on:
       - master
 
 jobs:
-  build:
-    name: Build
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,23 +32,17 @@ jobs:
         uses: getsentry/paths-filter@v2
         id: changes
         with:
-            token: ${{ github.token }}
-            filters: .github/file-filters.yml
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
 
-      - name: Set up Go 1.14
+      - name: setup go
+        if: steps.changes.outputs.go == 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
-        
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: check-diff
-          path: /tmp/swctl/check.diff
+          go-version: '1.13'
 
-      - name: Build
-        run: make build -j3
-
-      - name: Test commands
-        if: steps.changes.outputs.code-changes == 'true'
-        run: make test-commands
+      - name: run unit tests and report coverage
+        if: steps.changes.outputs.go == 'true'
+        working-directory: ./
+        run: |
+          make coverage

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint: tools
 	$(GO_LINT) run -v --timeout 5m ./...
 
 .PHONY: test
-test: clean lint
+test: clean
 	$(GO_TEST) ./... -coverprofile=coverage.txt -covermode=atomic
 
 .PHONY: build
@@ -101,7 +101,7 @@ coverage: test
 	bash <(curl -s https://codecov.io/bash) -t a5af28a3-92a2-4b35-9a77-54ad99b1ae00
 
 .PHONY: clean
-clean: tools
+clean:
 	-rm -rf bin
 	-rm -rf coverage.txt
 	-rm -rf *.tgz


### PR DESCRIPTION
Currently, the CI is time-consuming and will be triggered when make non-code changes.
So I split into multiple github action workflows for linting, unit testing and license checking, respectively. They can run parallelly, and only be trigged for go-related files.