### PR TITLE
Cancel the color text effect of swctl in windows

### DIFF
--- a/cmd/swctl/main.go
+++ b/cmd/swctl/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	"github.com/apache/skywalking-cli/internal/commands/completion"
 	"github.com/apache/skywalking-cli/internal/commands/dashboard"
@@ -51,9 +52,11 @@ func init() {
 }
 
 func main() {
-	cli.AppHelpTemplate = util.AppHelpTemplate
-	cli.CommandHelpTemplate = util.CommandHelpTemplate
-	cli.SubcommandHelpTemplate = util.SubcommandHelpTemplate
+	if runtime.GOOS != "windows" {
+		cli.AppHelpTemplate = util.AppHelpTemplate
+		cli.CommandHelpTemplate = util.CommandHelpTemplate
+		cli.SubcommandHelpTemplate = util.SubcommandHelpTemplate
+	}
 
 	app := cli.NewApp()
 	app.Usage = "The CLI (Command Line Interface) for Apache SkyWalking."


### PR DESCRIPTION
When using swctl in Windows, the terminal cannot display colored text normally ( It can be displayed normally in Linux and darwin ) , as shown in the figure below :

<img width="710" alt="Snipaste_2021-07-31_07-31-57" src="https://user-images.githubusercontent.com/52828870/130248823-f0c8c62d-5b1b-4d5a-9392-2f8a4c284c43.png">

so I temporarily canceled this effect in Windows.