### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,26 @@ Changes by Version
 ==================
 Release Notes.
 
+0.9.0
+------------------
+
+### Features
+
+- Add the sub-command `dependency instance` to query instance relationships (#117)
+
+### Bug Fixes
+
+- fix: `multiple-linear` command's `labels` type can be string type (#122)
+- Add missing `dest-service-id` `dest-service-name` to `metrics linear` command (#121)
+- Fix the wrong name when getting `destInstance` flag (#118)
+
+### Chores
+
+- Upgrade Go version to 1.16 (#120)
+- Migrate tests to infra-e2e, overhaul the flags names (#119)
+- Publish Docker snapshot images to ghcr (#116)
+- Remove dist directory when build release source tar (#115)
+
 0.8.0
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VERSION
-
 FROM golang:1.16 AS builder
 
+ARG VERSION
+
+ENV VERSION=$VERSION
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 
@@ -28,7 +29,7 @@ RUN go mod download
 
 COPY . .
 
-RUN make linux && mv bin/swctl-*-linux-amd64 /swctl
+RUN make install DESTDIR=/
 
 FROM alpine
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ check-codegen:
 	fi
 
 .PHONY: docker
-docker:
+docker: clean
 	docker build --build-arg VERSION=$(VERSION) . -t $(HUB)/$(APP_NAME):$(VERSION)
 
 .PHONY: docker.push


### PR DESCRIPTION
The main goal of this release is to initialize our docker image and simplify our main repo's Docker images when referencing to this tool