### PR TITLE
Add `.github/scripts` to release source tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,6 @@ release-src: clean
 	--exclude .git \
 	--exclude .idea \
 	--exclude .DS_Store \
-	--exclude .github \
 	--exclude dist \
 	--exclude $(RELEASE_SRC).tgz \
 	.


### PR DESCRIPTION
Otherwise users won't be able to build Docker images because building Docker images from the src requires the files under `.github/scripts`