### PR TITLE
Fix a possible lint error and update CI lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -47,5 +47,5 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.41.1
+          version: latest
           args: --timeout 5m

--- a/pkg/graphql/metadata/metadata.go
+++ b/pkg/graphql/metadata/metadata.go
@@ -261,7 +261,11 @@ func backendMajorVersion(cliCtx *cli.Context) (int, error) {
 	if version == "" {
 		return 0, fmt.Errorf("failed to detect OAP version")
 	}
-	majorVersion := version[:strings.Index(version, ".")]
+	idx := strings.Index(version, ".")
+	if idx < 0 {
+		idx = 0
+	}
+	majorVersion := version[:idx]
 	atoi, err := strconv.Atoi(majorVersion)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
- Fix the lint error caused by OffBy1 check in newer-version lint.
- Update the lint version to 'latest' in CI.