### PR TITLE
Add the components field in the process relation

### DIFF
--- a/assets/graphqls/dependency/ProcessTopology.graphql
+++ b/assets/graphqls/dependency/ProcessTopology.graphql
@@ -31,6 +31,8 @@ query ($serviceInstanceId: ID!, $duration: Duration!){
             target
             id
             detectPoints
+            sourceComponents
+            targetComponents
         }
     }
 }


### PR DESCRIPTION
Add the components field in the process relation to knowledge of the transport layer type. 
Since the process dependency is added in this milestone, I haven't updated the change log. 