### PR TITLE
Add the attached events fields into the `trace` sub-command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Release Notes.
 * Add the sub-commands for query sorted metrics/records by @mrproliu in https://github.com/apache/skywalking-cli/pull/163
 * Add compatibility documentation by @mrproliu in https://github.com/apache/skywalking-cli/pull/164
 * Add the sub-command `records list` for adapt the new record query API by @mrproliu in https://github.com/apache/skywalking-cli/pull/167
+* Add the attached events fields into the `trace` sub-command by @mrproliu in https://github.com/apache/skywalking-cli/pull/169
 
 0.10.0
 ------------------

--- a/assets/graphqls/trace/Trace.graphql
+++ b/assets/graphqls/trace/Trace.graphql
@@ -46,6 +46,21 @@ query ($traceId: ID!) {
                     key value
                 }
             }
+            attachedEvents {
+                startTime {
+                    seconds nanos
+                }
+                event
+                endTime {
+                    seconds nanos
+                }
+                tags {
+                    key value
+                }
+                summary {
+                    key value
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Following https://github.com/apache/skywalking/issues/9803, adding the SpanAttachedEvent-related field to the CLI for E2E testing. 