### PR TITLE
Exit code should be non-0 when a command is not found

### DIFF
--- a/pkg/util/commandNotFound.go
+++ b/pkg/util/commandNotFound.go
@@ -19,6 +19,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli/v2"
 )
@@ -55,6 +56,7 @@ func CommandNotFound(c *cli.Context, s string) {
 	} else {
 		fmt.Printf("Run 'swctl %s --help' for usage.\n", parentCommand)
 	}
+	os.Exit(1)
 }
 
 // minEditDistance calculates the edit distance of two strings.


### PR DESCRIPTION
But because upstream cli module doesn't allow returning an `error` in the `CommandNotFoundFunc`, we have to call `os.exit(1)` here

https://github.com/urfave/cli/issues/611