### PR TITLE
Fix the record list query does not support new OAP versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Release Notes.
 ------------------
 
 ### Features
+
+### Bug Fixes
+
+* Fix the record list query does not support new OAP versions (with major version number > 9).
+
 ## What's Changed
 
 * Add the sub-command `menu get` for get the ui menu items by @mrproliu in https://github.com/apache/skywalking-cli/pull/187

--- a/internal/commands/metrics/aggregation/sampled-record.go
+++ b/internal/commands/metrics/aggregation/sampled-record.go
@@ -76,7 +76,7 @@ $ swctl metrics sampled-record --name top_n_database_statement 5
 		}
 
 		// since 9.3.0, use new record query API
-		if major >= 9 && minor >= 3 {
+		if (major == 9 && minor >= 3) || major > 9 {
 			condition, duration, err1 := buildReadRecordsCondition(ctx)
 			if err1 != nil {
 				return err1


### PR DESCRIPTION
Since the OAP version is ready to be upgraded to version 10, the record list query currently only supports the new query method for version 9.3.0 and cannot adapt to version 10.