### PR TITLE
Update CHANGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ Release Notes.
 
 ### Features
 
-* add the sub-command `profiling async` for async-profiler query API by @zhengziyi0117 in https://github.com/apache/skywalking-cli/pull/203
+* Add the sub-command `profiling async` for async-profiler query API by @zhengziyi0117 in https://github.com/apache/skywalking-cli/pull/203
+* Support the owner in MQE response by using [10.2 MQE query protocol](https://github.com/apache/skywalking-query-protocol/pull/141) by @zhengziyi0117 in https://github.com/apache/skywalking-cli/pull/203
 
 ### Bug Fixes
 


### PR DESCRIPTION
https://github.com/apache/skywalking-cli/pull/203 introduced another feature in the CLI. 

https://github.com/apache/skywalking/pull/12816 keeps CI failing as new field in response. 

<img width="859" alt="image" src="https://github.com/user-attachments/assets/0d243fb4-0b8d-411b-9569-3aa258684790">
