### PR TITLE
Fix CI workflows: approved docker/login-action SHA + retry flaky docker build

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -84,7 +84,10 @@ jobs:
         run: make build -j3
 
       - name: Build Docker images
-        run: make docker
+        # Retry once: booting buildkit pulls moby/buildkit from Docker Hub, which
+        # intermittently times out on shared runners. Mirrors publish-docker.yaml's
+        # `make docker.push || make docker.push`.
+        run: make docker || make docker
 
 
   command-tests:

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: "1.26"
       - name: Log in to the Container registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}


### PR DESCRIPTION
Two CI-workflow robustness fixes surfaced by the master CI run after #228.

## 1. `publish-docker.yaml` — approved `docker/login-action` SHA

The ASF GitHub Actions policy only permits third-party actions pinned to an allowed commit SHA, so `docker/login-action@v1.10.0` (a version tag) is rejected:

> The action `docker/login-action@v1.10.0` is not allowed in apache/skywalking-cli because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns …

Pinned to `c94ce9fb468520275223c153574b00df6fe4bcc9` — the same revision the [apache/skywalking](https://github.com/apache/skywalking) workflows already use (so it's on the ASF allow-list). Inputs (`registry`/`username`/`password`) are unchanged, so it's a drop-in change. This was the only blocked action in the repo.

## 2. `CI.yaml` Build job — retry the docker build

The `Build` job's `make docker` step boots buildkit by pulling `moby/buildkit:buildx-stable-1` from Docker Hub, which intermittently times out on shared runners:

```
#1 pulling image moby/buildkit:buildx-stable-1
#1 ERROR: Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded while awaiting headers
make: *** [Makefile:168: docker] Error 1
```

This flaked the Build job (and the Required gate) on the post-#228 master run, while all other jobs — including the new e2e suites — passed. Added a single retry (`make docker || make docker`), mirroring the existing `make docker.push || make docker.push` pattern already used in `publish-docker.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)