### PR TITLE
Add --value-column / --value-type to `admin inspect entities` for foreign-metric inspect

### DIFF
--- a/internal/commands/admin/inspect/inspect.go
+++ b/internal/commands/admin/inspect/inspect.go
@@ -92,7 +92,11 @@ Each row carries an MQE-ready entity to paste into a follow-up "swctl metrics ex
 
 Examples:
 1. Entities reporting service_cpm in the last 30 minutes:
-$ swctl admin inspect entities --metric service_cpm`,
+$ swctl admin inspect entities --metric service_cpm
+
+2. Inspect a metric persisted by ANOTHER OAP (not defined on this OAP) — supply its value
+   column + type so the OAP resolves it from storage without its local registry:
+$ swctl admin inspect entities --metric meter_foo --value-column value --value-type LONG`,
 	Flags: flags.Flags(
 		flags.DurationFlags,
 		[]cli.Flag{
@@ -104,6 +108,14 @@ $ swctl admin inspect entities --metric service_cpm`,
 			&cli.IntFlag{
 				Name:  "limit",
 				Usage: fmt.Sprintf("max rows scanned at the storage layer (1-%d, server default 300)", inspect.MaxLimit),
+			},
+			&cli.StringFlag{
+				Name:  "value-column",
+				Usage: "the metric's value `column` (e.g. value, value_, double_value); REQUIRED when the metric is not defined on the target OAP",
+			},
+			&cli.StringFlag{
+				Name:  "value-type",
+				Usage: "value data `type` (LONG / INT / DOUBLE / LABELED); REQUIRED when the metric is not defined on the target OAP",
 			},
 		},
 	),
@@ -118,11 +130,13 @@ $ swctl admin inspect entities --metric service_cpm`,
 		step := ctx.Generic("step").(*model.StepEnumValue).Selected
 
 		entities, err := inspect.ListEntities(ctx.Context, inspect.EntitiesOptions{
-			Metric: ctx.String("metric"),
-			Start:  ctx.String("start"),
-			End:    ctx.String("end"),
-			Step:   string(step),
-			Limit:  limit,
+			Metric:      ctx.String("metric"),
+			Start:       ctx.String("start"),
+			End:         ctx.String("end"),
+			Step:        string(step),
+			Limit:       limit,
+			ValueColumn: ctx.String("value-column"),
+			ValueType:   ctx.String("value-type"),
 		})
 		if err != nil {
 			return preflight.Explain(ctx.Context, err, preflight.ModuleInspect, "SW_INSPECT")

--- a/internal/commands/admin/inspect/inspect.go
+++ b/internal/commands/admin/inspect/inspect.go
@@ -129,7 +129,7 @@ $ swctl admin inspect entities --metric meter_foo --value-column value --value-t
 		}
 		step := ctx.Generic("step").(*model.StepEnumValue).Selected
 
-		entities, err := inspect.ListEntities(ctx.Context, inspect.EntitiesOptions{
+		entities, err := inspect.ListEntities(ctx.Context, &inspect.EntitiesOptions{
 			Metric:      ctx.String("metric"),
 			Start:       ctx.String("start"),
 			End:         ctx.String("end"),

--- a/pkg/admin/inspect/inspect.go
+++ b/pkg/admin/inspect/inspect.go
@@ -112,7 +112,7 @@ func ListMetrics(ctx context.Context, opts MetricsOptions) (*Metrics, error) {
 
 // ListEntities enumerates the entities holding values for a metric over a time range
 // (GET /inspect/entities). Only REGULAR_VALUE / LABELED_VALUE metrics are accepted.
-func ListEntities(ctx context.Context, opts EntitiesOptions) (*Entities, error) {
+func ListEntities(ctx context.Context, opts *EntitiesOptions) (*Entities, error) {
 	query := url.Values{}
 	query.Set("metric", opts.Metric)
 	query.Set("start", opts.Start)

--- a/pkg/admin/inspect/inspect.go
+++ b/pkg/admin/inspect/inspect.go
@@ -82,6 +82,11 @@ type EntitiesOptions struct {
 	End    string
 	Step   string
 	Limit  int
+	// ValueColumn / ValueType are required only when the metric is NOT defined on the target OAP
+	// (a metric persisted by another OAP). When set, the OAP resolves the metric from storage
+	// using this caller-supplied metadata instead of its local registry.
+	ValueColumn string
+	ValueType   string
 }
 
 // ListMetrics lists the registered metric catalog (GET /inspect/metrics).
@@ -115,6 +120,12 @@ func ListEntities(ctx context.Context, opts EntitiesOptions) (*Entities, error) 
 	query.Set("step", opts.Step)
 	if opts.Limit > 0 {
 		query.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.ValueColumn != "" {
+		query.Set("valueColumn", opts.ValueColumn)
+	}
+	if opts.ValueType != "" {
+		query.Set("valueType", opts.ValueType)
 	}
 
 	var out Entities


### PR DESCRIPTION
### What

Adds two flags to `swctl admin inspect entities`:

- `--value-column` — the metric's value column (e.g. `value`, `value_`, `double_value`)
- `--value-type` — value data type (`LONG` / `INT` / `DOUBLE` / `LABELED`)

Both are passed through as query params to `GET /inspect/entities` and are **required only when the metric is not defined on the target OAP** — i.e. a metric persisted by *another* OAP that this node never loaded the OAL/MAL/runtime-rule for.

### Why

SkyWalking OAP's inspect API was extended so `/inspect/entities` can inspect a metric persisted by any OAP, even one the queried node does not define locally. Since the value column/type cannot be recovered from the metric name in that case, the caller supplies them. This change lets `swctl` drive that foreign-metric path (otherwise the new capability is only reachable via raw curl).

For a locally-defined metric the flags are ignored, so existing usage is unchanged.

### Example

```
swctl admin inspect entities --metric meter_foo --value-column value --value-type LONG \
  --start "2026-06-23 0840" --end "2026-06-23 0900" --step MINUTE
```