### PR TITLE
Fix publish-docker startup_failure: use ASF-approved docker/login-action SHA

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: "1.26"
       - name: Log in to the Container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}


### PR DESCRIPTION
### Fix the `publish-docker` workflow `startup_failure` on master push

`publish-docker.yaml` pinned `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9` (set in #229). That SHA is **not** on the [ASF GitHub Actions allow-list](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml), so the workflow is rejected at **`startup_failure`** before any job runs.

Because `publish-docker` triggers only on `push: branches: [master]`, no PR ever exercises it — so #229's bad SHA passed PR CI and only failed post-merge (e.g. https://github.com/apache/skywalking-cli/actions/runs/28028423025).

Switch to `docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee` (v4.2.0), which **is** on the approved list and is the exact SHA `apache/skywalking`, `apache/skywalking-banyandb`, and `apache/skywalking-infra-e2e` all use. It's the only third-party action in any cli workflow.

- [ ] This is a CI-only fix; no unit test applies.