### PR TITLE
Document the `meter-analyzer-config` catalog in `admin runtime-rule` / `admin dsl-debug`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Release Notes.
 * Add the sub-command `profiling pprof` for pprof query API by @JophieQu in https://github.com/apache/skywalking-cli/pull/226
 * Add the `admin` command group for the OAP admin-server REST host (default port `17128`), with a new global `--admin-url` flag (derived from `--base-url` when unset). Covers every admin feature module: `admin preflight`; `admin cluster nodes`, `admin config dump|ttl`, `admin alarm rules|rule` (status); `admin inspect metrics|entities` (inspect); `admin ui-template list|get|create|update|disable` (ui-management); `admin runtime-rule list|bundled|get|add|inactivate|delete|dump` (runtime-rule); and `admin dsl-debug status|sessions|session start|get|stop` plus `admin oal files|file|rules|rule` (dsl-debugging).
 * Add the sub-command `admin inspect values` to read the VALUES of metric(s) an OAP does not define locally (foreign metrics) by supplying their `{valueColumn, valueType}` metadata, via the new `POST /inspect/values` admin API; returns the native MQE result.
+* Document the `meter-analyzer-config` catalog in `admin runtime-rule` and `admin dsl-debug session start`, matching the OAP-side support for native meter rule hot-update and MAL DSL debugging.
 
 ### Bug Fixes
 

--- a/internal/commands/admin/dsldebug/dsldebug.go
+++ b/internal/commands/admin/dsldebug/dsldebug.go
@@ -86,7 +86,7 @@ $ swctl admin dsl-debug session start --catalog otel-rules --name vm --rule-name
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "catalog",
-			Usage:    "session `catalog`: otel-rules / log-mal-rules / telegraf-rules / lal / oal",
+			Usage:    "session `catalog`: otel-rules / log-mal-rules / telegraf-rules / meter-analyzer-config / lal / oal",
 			Required: true,
 		},
 		&cli.StringFlag{

--- a/internal/commands/admin/runtimerule/runtimerule.go
+++ b/internal/commands/admin/runtimerule/runtimerule.go
@@ -36,7 +36,7 @@ var Command = &cli.Command{
 	UsageText: `Add, override, inactivate and delete MAL / LAL rule files at runtime without
 restarting OAP, and inspect the live and bundled rule state.
 
-Catalogs: otel-rules, log-mal-rules, telegraf-rules, lal.`,
+Catalogs: otel-rules, log-mal-rules, telegraf-rules, meter-analyzer-config, lal.`,
 	Subcommands: []*cli.Command{
 		listCommand,
 		bundledCommand,
@@ -51,7 +51,7 @@ Catalogs: otel-rules, log-mal-rules, telegraf-rules, lal.`,
 func catalogFlag(required bool) cli.Flag {
 	return &cli.StringFlag{
 		Name:     "catalog",
-		Usage:    "rule `catalog`: otel-rules / log-mal-rules / telegraf-rules / lal",
+		Usage:    "rule `catalog`: otel-rules / log-mal-rules / telegraf-rules / meter-analyzer-config / lal",
 		Required: required,
 	}
 }

--- a/pkg/admin/dsldebug/dsldebug.go
+++ b/pkg/admin/dsldebug/dsldebug.go
@@ -36,9 +36,6 @@ const (
 	MaxRetentionMillis = 60 * 60 * 1000
 )
 
-// Catalogs accepted by a debug session.
-var Catalogs = []string{"otel-rules", "log-mal-rules", "telegraf-rules", "lal", "oal"}
-
 // StartArgs holds the inputs of POST /dsl-debugging/session. Catalog, Name, RuleName
 // and ClientID are mandatory query params; RecordCap / RetentionMillis are optional and
 // sent as a JSON body only when set. Granularity (LAL only) is sent as a query param.

--- a/pkg/admin/runtimerule/runtimerule.go
+++ b/pkg/admin/runtimerule/runtimerule.go
@@ -31,9 +31,6 @@ import (
 	"github.com/apache/skywalking-cli/pkg/admin/client"
 )
 
-// Catalogs accepted by the runtime-rule endpoints.
-var Catalogs = []string{"otel-rules", "log-mal-rules", "telegraf-rules", "lal"}
-
 // ApplyResult is the JSON envelope returned by addOrUpdate / inactivate / delete.
 type ApplyResult struct {
 	ApplyStatus string `json:"applyStatus"`


### PR DESCRIPTION
### Context

[apache/skywalking#13969](https://github.com/apache/skywalking/pull/13969) brings the `meter-analyzer-config` catalog (native `MeterReportService` rules) to parity with `otel-rules`: those rules now load through the shared `Rules`/`RuleSetMerger` pipeline, so a meter rule can be hot-added, structurally edited, or inactivated at runtime, and attached to a MAL DSL debug session — without restarting OAP.

### Does swctl need a functional change? No.

On the wire that OAP change is **purely additive** — one more value in the shared `Catalog` enum:

```java
 OTEL_RULES("otel-rules"),
 LOG_MAL_RULES("log-mal-rules"),
 TELEGRAF_RULES("telegraf-rules"),
+METER_ANALYZER_CONFIG("meter-analyzer-config"),
 LAL("lal"),
```

No new endpoints, no new request/response fields, no changed payload shapes. And swctl already passes it through:

* There is no client-side catalog allow-list — `--catalog` reaches the server verbatim.
* `pkg/admin/runtimerule` only ever calls the **canonical** `/runtime/rule/{list,bundled,addOrUpdate,inactivate,delete,dump}` routes; it never maps a catalog onto the `/runtime/mal/otel`-style shortcuts. That matters, because `meter-analyzer-config` is one of the two catalogs (with `telegraf-rules`) that deliberately has no shortcut route.

The e2e added in that same OAP PR (`test/e2e-v2/cases/runtime-rule/meter/meter-runtime-rule-flow.sh`) is the proof: it sets `CATALOG="meter-analyzer-config"` and drives all five phases — bundled visibility, hot add, structural edit with converter replacement, DSL debug session, inactivate — entirely through `swctl admin runtime-rule …` and `swctl admin dsl-debug session …` against an unmodified CLI.

### What this PR does

What *was* stale is discoverability — `--help` still advertised only four catalogs.

* Add `meter-analyzer-config` to the `--catalog` flag help of `admin runtime-rule` and `admin dsl-debug session start`, and to the `admin runtime-rule` catalog list.
* Drop the two unreferenced `Catalogs` vars in `pkg/admin/{runtimerule,dsldebug}`. Nothing read them — they were a second copy of the catalog list, free to drift out of sync with OAP's enum, and this change is exactly the drift they would have caused. The rendered help text is now the single place the list lives; keeping it out of a client-side allow-list means a newer OAP catalog keeps working without a CLI release.
* `CHANGES.md` entry under 0.15.0.

### Verification

```
$ swctl admin runtime-rule add --help
  --catalog catalog  rule catalog: otel-rules / log-mal-rules / telegraf-rules / meter-analyzer-config / lal

$ swctl admin dsl-debug session start --help
  --catalog catalog  session catalog: otel-rules / log-mal-rules / telegraf-rules / meter-analyzer-config / lal / oal
```

`go build ./...`, `go vet`, and `go test ./pkg/admin/... ./internal/commands/admin/...` all pass. `make lint` fails identically before and after (40 pre-existing `lll` violations in untouched files); this change adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)